### PR TITLE
Pin squid package version to PPA.

### DIFF
--- a/cookbooks/squid/recipes/default.rb
+++ b/cookbooks/squid/recipes/default.rb
@@ -20,6 +20,21 @@
 # Use osmadmins PPA squid packages
 include_recipe "apt"
 
+# Pin the osmadmins PPA package version for squid to make sure that a more
+# recent one from Ubuntu is not picked up. Note that this pins the package
+# to a version from *any* PPA - would be better to pin it to the osmadmins
+# one, but I can't see how.
+file '/etc/apt/preferences.d/pin-squid-to-osmadmins-ppa' do
+  content <<EOF
+Package: squid squid-common
+Pin: origin ppa.launchpad.net
+Pin-Priority: 1001
+EOF
+  owner "root"
+  group "root"
+  mode 0o644
+end
+
 package "squid"
 package "squidclient"
 


### PR DESCRIPTION
This adds a preference file to pin the `squid` and `squid-common` packages to versions found in PPAs.

Unfortunately, it's pinned to a `squid` package from _any_ PPA, whereas a StackOverflow [answer to a similar question](http://askubuntu.com/questions/170235/how-do-i-cherry-pick-packages-from-a-ppa#answer-170265) suggests that we should be able to use `Pin: release o=LP-PPA-osmadmins-ppa`, but that doesn't appear in the output of `apt-cache policy squid` for me:

```
vagrant@squid-ubuntu-1604:~$ apt-cache policy squid
squid:
  Installed: 2.7.STABLE9-4ubuntu10
  Candidate: 2.7.STABLE9-4ubuntu10
  Version table:
     3.5.12-1ubuntu7.2 500
        500 http://gb.archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages
        500 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages
     3.5.12-1ubuntu7 500
        500 http://gb.archive.ubuntu.com/ubuntu xenial/main amd64 Packages
 *** 2.7.STABLE9-4ubuntu10 1001
        500 http://ppa.launchpad.net/osmadmins/ppa/ubuntu xenial/main amd64 Packages
        100 /var/lib/dpkg/status
```

I'm not sure why that information doesn't appear for any of the packages here - not even the upstream Ubuntu ones.
